### PR TITLE
feat:account/profile screen and reusable components

### DIFF
--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -59,7 +59,7 @@ export default function RootLayout() {
             title: 'Friends',
             headerShown: false,
             tabBarIcon: ({ size, color }) => (
-              <MaterialIcons name={'person'} size={32} color={color} />
+              <MaterialIcons name={'people'} size={32} color={color} />
             ),
           }}
         />
@@ -101,6 +101,16 @@ export default function RootLayout() {
           options={{
             href: null,
             headerShown: false,
+          }}
+        />
+        <Tabs.Screen
+          name="account/index"
+          options={{
+            title: 'Account',
+            headerShown: false,
+            tabBarIcon: ({ size, color }) => (
+              <MaterialIcons name="person" size={32} color={color} />
+            ),
           }}
         />
       </Tabs>

--- a/src/app/(tabs)/account/index.tsx
+++ b/src/app/(tabs)/account/index.tsx
@@ -1,0 +1,73 @@
+import AccountList from '@/src/components/customUI/AccountList';
+import AvatarWithLabel from '@/src/components/customUI/AvatarWithLabel';
+import { HStack } from '@/src/components/customUI/HStack';
+import Separator from '@/src/components/customUI/Separator';
+import { VStack } from '@/src/components/customUI/VStack';
+import Header from '@/src/components/header/header';
+import { COLORS } from '@/src/providers/theme.style';
+import Feather from '@expo/vector-icons/Feather';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { faker } from '@faker-js/faker/.';
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+const Account = () => {
+  const featuresList = [
+    {
+      name: 'Additions',
+      subList: [
+        {
+          heading: 'Scan QR Code',
+          subHeading: 'Use QR Code to add a friend',
+          icon: <Ionicons name="qr-code" size={28} color={COLORS.primary} />,
+        },
+        {
+          heading: 'Get Premium',
+          subHeading: 'Unlock the premium with 25% discount',
+          icon: <Ionicons name="diamond" size={28} color={COLORS.primary} />,
+        },
+      ],
+    },
+    {
+      name: 'Additions',
+      subList: [
+        {
+          heading: 'Scan QR Code',
+          subHeading: 'Use QR Code to add a friend',
+          icon: <Ionicons name="qr-code" size={28} color={COLORS.primary} />,
+        },
+        {
+          heading: 'Get Premium',
+          subHeading: 'Unlock the premium with 25% discount',
+          icon: <Ionicons name="diamond" size={28} color={COLORS.primary} />,
+        },
+      ],
+    },
+  ];
+  return (
+    <View style={styles.flex1}>
+      <Header title="Account" />
+      <VStack style={styles.container}>
+        <HStack style={{ justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+          <AvatarWithLabel
+            uri={faker.image.avatar()}
+            label="Rishabh Parsediya"
+            subLabel="parsediyarishabh@gmail.com"
+          />
+          <Feather name="edit" size={24} color={COLORS.primary} />
+        </HStack>
+        <Separator />
+        <AccountList featuresList={featuresList} />
+      </VStack>
+    </View>
+  );
+};
+
+export default Account;
+
+const styles = StyleSheet.create({
+  container: { paddingHorizontal: 16 },
+  flex1: {
+    flex: 1,
+  },
+});

--- a/src/app/addExpense/index.tsx
+++ b/src/app/addExpense/index.tsx
@@ -31,7 +31,7 @@ const AddExpense = () => {
     amountRef,
     onAddExpense,
   } = useAddExpense({
-    groupId: groupId.toString() ?? '',
+    groupId: groupId?.toString() ?? '',
   });
 
   return (

--- a/src/components/customUI/AccountList.tsx
+++ b/src/components/customUI/AccountList.tsx
@@ -1,0 +1,94 @@
+import { COLORS } from '@/src/providers/theme.style';
+import AntDesign from '@expo/vector-icons/AntDesign';
+import React from 'react';
+import { FlatList, StyleSheet, Text, TextProps, View } from 'react-native';
+import { HStack } from './HStack';
+import Separator from './Separator';
+import { VStack } from './VStack';
+type FeatureIconProps = {
+  name: string;
+  size: number;
+  color: string;
+} & Partial<TextProps>;
+
+type SubFeature = {
+  heading: string;
+  subHeading: string;
+  icon: React.ReactElement<FeatureIconProps> | string;
+};
+
+type Feature = {
+  name: string;
+  subList: SubFeature[];
+};
+
+type FeaturesListProps = {
+  featuresList: Feature[];
+};
+
+const AccountList = ({ featuresList }: FeaturesListProps) => {
+  const renderSubFeature = ({ item }: { item: SubFeature }) => (
+    <HStack>
+      <View style={[styles.center, styles.iconContainer]}>
+        {typeof item.icon === 'string' ? <Text>{item.icon}</Text> : item.icon}
+      </View>
+      <HStack style={[styles.center, styles.subList]}>
+        <View>
+          <Text style={styles.font}>{item.heading}</Text>
+          <Text style={styles.subHeading}>{item.subHeading}</Text>
+        </View>
+        <AntDesign style={styles.alignSelf} name="right" size={16} color={COLORS.primary} />
+      </HStack>
+    </HStack>
+  );
+  const renderItem = ({ item }: { item: Feature }) => {
+    return (
+      <VStack>
+        <Text style={[styles.font, styles.featureName]}>{item.name}</Text>
+        <FlatList
+          data={item.subList}
+          keyExtractor={(_, subIndex) => `${item.name}-${subIndex}`}
+          renderItem={renderSubFeature}
+        />
+      </VStack>
+    );
+  };
+  return (
+    <VStack>
+      <FlatList
+        data={featuresList}
+        keyExtractor={(_, index) => String(index)}
+        renderItem={renderItem}
+        ItemSeparatorComponent={() => <Separator />}
+      />
+    </VStack>
+  );
+};
+
+export default AccountList;
+
+const styles = StyleSheet.create({
+  featureName: {
+    fontSize: 16,
+    marginVertical: 4,
+  },
+  alignSelf: { alignSelf: 'center' },
+  subList: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    justifyContent: 'space-between',
+    flex: 1,
+  },
+  font: {
+    color: 'white',
+  },
+  center: {
+    justifyContent: 'center',
+  },
+  iconContainer: {
+    paddingVertical: 12,
+  },
+  subHeading: {
+    color: COLORS.dark25,
+  },
+});

--- a/src/components/customUI/AvatarWithLabel.tsx
+++ b/src/components/customUI/AvatarWithLabel.tsx
@@ -1,0 +1,48 @@
+import { COLORS } from '@/src/providers/theme.style';
+import React from 'react';
+import { Image, StyleSheet, Text, View } from 'react-native';
+import { HStack } from './HStack';
+
+export interface AvatarWithLabelProps {
+  uri: string;
+  label: string;
+  subLabel: string;
+}
+
+const AvatarWithLabel = ({ uri, label, subLabel }: AvatarWithLabelProps) => {
+  return (
+    <HStack style={styles.container}>
+      <Image style={styles.image} source={{ uri: uri }} />
+      <View style={styles.labelsContainer}>
+        <Text style={[styles.font, styles.label]}>{label}</Text>
+        <Text style={[styles.font, styles.subLabel]}>{subLabel}</Text>
+      </View>
+    </HStack>
+  );
+};
+
+export default AvatarWithLabel;
+
+const styles = StyleSheet.create({
+  container: {},
+  image: {
+    height: 80,
+    width: 80,
+    borderRadius: 50,
+  },
+  labelsContainer: {
+    justifyContent: 'center',
+    paddingHorizontal: 12,
+  },
+  font: {
+    color: 'white',
+  },
+  label: {
+    fontSize: 18,
+  },
+  subLabel: {
+    fontSize: 14,
+    color: COLORS.dark25,
+    fontWeight: '700',
+  },
+});

--- a/src/components/customUI/Separator.tsx
+++ b/src/components/customUI/Separator.tsx
@@ -1,0 +1,16 @@
+import { COLORS } from '@/src/providers/theme.style';
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+const Separator = () => <View style={styles.separator} />;
+
+export default Separator;
+
+const styles = StyleSheet.create({
+  separator: {
+    height: 1,
+    backgroundColor: COLORS.dark25,
+    marginVertical: 8,
+    borderRadius: 100,
+  },
+});


### PR DESCRIPTION
Added account/profile screen along with reusable components like AvatarWithLabel, Separator, FeaturesListGroup.

Need to remove one inline styling(later).
<img width="337" alt="Screenshot 2024-12-22 at 9 29 08 AM" src="https://github.com/user-attachments/assets/7a4c2fe1-26e4-43db-aede-a756119f496b" />



